### PR TITLE
Fixed the two-way contingency table

### DIFF
--- a/vignettes/T20.Rmd
+++ b/vignettes/T20.Rmd
@@ -81,9 +81,12 @@ We can do some contingency tables:
 
 ```{r}
 M <- table(
-won_toss_won_match = T20_table$toss_winner==T20_table$match_winner,
-decision           = T20_table$toss_decision)
-dimnames(M) <- list(thing=c('won_toss_won_match','won_toss_lost_match'),decision=c('bat','field'))
+decision           = T20_table$toss_decision,
+won_toss_won_match = T20_table$toss_winner==T20_table$match_winner)
+M
+dimnames(M) <- list(
+decision=c('bat first','field first'),
+won_match =c(FALSE,TRUE))
 M
 ```
 


### PR DESCRIPTION
Transposed the two-way contingency table and fixed the order of winning and losing the match being cause due to reversed order of true and false.